### PR TITLE
Eliminate warnings

### DIFF
--- a/elscreen-buffer-group.el
+++ b/elscreen-buffer-group.el
@@ -238,7 +238,7 @@ if any, so that this only matches/returns buffers in the current elscreen."
 
 (defadvice elscreen-kill (before elscreen-buffer-group-kill-buffers activate)
   "When you kill a screen, kill all the buffers in its list."
-  (mapcar (lambda (b) (kill-buffer b)) (elscreen-buffer-group-get-raw-buffer-list)))
+  (mapc (lambda (b) (kill-buffer b)) (elscreen-buffer-group-get-raw-buffer-list)))
 
 (defadvice switch-to-prev-buffer (around elscreen-buffer-group-switch-to-prev-buffer activate)
 "This is for when you kill a buffer.

--- a/elscreen-buffer-group.el
+++ b/elscreen-buffer-group.el
@@ -238,7 +238,7 @@ if any, so that this only matches/returns buffers in the current elscreen."
 
 (defadvice elscreen-kill (before elscreen-buffer-group-kill-buffers activate)
   "When you kill a screen, kill all the buffers in its list."
-  (mapcar '(lambda (b) (kill-buffer b)) (elscreen-buffer-group-get-raw-buffer-list)))
+  (mapcar (lambda (b) (kill-buffer b)) (elscreen-buffer-group-get-raw-buffer-list)))
 
 (defadvice switch-to-prev-buffer (around elscreen-buffer-group-switch-to-prev-buffer activate)
 "This is for when you kill a buffer.


### PR DESCRIPTION
Eliminate 2 warnings as below

```
Warning (bytecomp): (lambda (b) ...) quoted with ' rather than with #'
Warning (bytecomp): ‘mapcar’ called for effect; use ‘mapc’ or ‘dolist’ instead
```
