### PR TITLE
Fixed runtime error with internal-complete-buffer

### DIFF
--- a/elscreen-buffer-group.el
+++ b/elscreen-buffer-group.el
@@ -230,7 +230,7 @@ Basically we hack in here and add another predicate to whatever predicates are a
 if any, so that this only matches/returns buffers in the current elscreen."
   (lexical-let ((string (ad-get-arg 0))
                 (pred (ad-get-arg 1)))
-    (when (not (member this-command 'elscreen-buffer-group-skip-commands))
+    (when (not (member this-command elscreen-buffer-group-skip-commands))
       (ad-set-arg 1 (lambda (buffer-dot-name)
                       (and (if pred (funcall pred buffer-dot-name) t)
                            (member (cdr buffer-dot-name) (elscreen-buffer-group-get-ordered-buffer-list)))))))


### PR DESCRIPTION
* Blew up because elscreen-buffer-group-skip-commands is a already a list and it
was being quoted in internal-complete-buffer which caused a runtime error
whenever internal-complete-buffer was being invoked as a result of
elscreen-buffer-group-filter-buffer-list being called